### PR TITLE
some things to facilitate turns happening

### DIFF
--- a/src/app/engine/entities.py
+++ b/src/app/engine/entities.py
@@ -343,7 +343,7 @@ class YahtzeeScore(GroupedScore):
 
 @dataclass(init=True)
 class Scorecard():
-    player: Player
+    player: str
     scores: List[Score] = field(default_factory=lambda: Scorecard._get_initial_scorecard())
 
     def get_valid_scores_for_roll(self, roll: Roll) -> List[Score]:
@@ -401,6 +401,7 @@ class Turn:
     last_roll: Roll = Roll()
     roll_count: int = 1
     selected_score_type: ScoreType = None
+    player: str = ""
 
     def roll_selected_dice(self, dice_to_roll: List[Die]):
         if self.roll_count == Turn.MAX_ROLL_COUNT:
@@ -416,5 +417,6 @@ class Turn:
         return {
             "last_roll": self.last_roll.to_json(),
             "roll_count": self.roll_count,
-            "selected_score_type": self.selected_score_type.value if self.selected_score_type else None
+            "selected_score_type": self.selected_score_type.value if self.selected_score_type else None,
+            "player": self.player
         }

--- a/src/app/engine/game_engine.py
+++ b/src/app/engine/game_engine.py
@@ -47,6 +47,7 @@ class GameEngine:
         if self._is_first_turn_of_game() or self.current_turn.is_turn_complete():
             self.current_scorecard = next(self.scorecards_cycle)
             self.current_turn = Turn()
+            self.current_turn.player = self.current_scorecard.player
 
     def _is_first_turn_of_game(self) -> bool:
         return self.current_turn is None

--- a/src/app/events/event.py
+++ b/src/app/events/event.py
@@ -9,7 +9,8 @@ VALID_EVENTS = [  # TODO: could make this an enum
     "game_started",
     "player_joined",
     "player_left",
-    "rolled_dice"
+    "rolled_dice",
+    "score_selected"
 ]
 
 

--- a/src/app/state/state_manager.py
+++ b/src/app/state/state_manager.py
@@ -78,7 +78,8 @@ class StateManager:
         self.transcribe_event(event)
 
     def score_selected(self, event: Event):
-        self.game_engine.score_selected(event.get_data()["selected_score_type"])
+        self.game_engine.select_score_for_roll(event.get_data()["selected_score_type"])
+        self.transcribe_event(event)
 
     def transcribe_event(self, event):
         message = Message(event)


### PR DESCRIPTION
Added turn player to gamestate, fixed score_selected() in state_manager so it calls the select_score_for_roll() in the game engine.
Also, the player variable in scorecards is now officially a string because websockets cannot be jsoned