### PR TITLE
Return a dictionary to the front end for the Scorecard

### DIFF
--- a/src/app/engine/entities.py
+++ b/src/app/engine/entities.py
@@ -374,8 +374,7 @@ class Scorecard():
 
     def to_dict(self):
         return {
-            "player": self.player.name,
-            "scores": [score.to_dict() for score in self.scores]
+            "scores": {score.score_type().value: score.calculate_points() for score in self.scores}
         }
 
     @staticmethod

--- a/src/app/state/state_manager.py
+++ b/src/app/state/state_manager.py
@@ -115,7 +115,7 @@ class StateManager:
                 "players": self.get_connected_players(),
                 "chat_transcript": self.chat_transcript.get_transcript(),
                 "game_transcript": self.game_transcript.get_transcript(),
-                "scorecards": [scorecard.to_dict() for scorecard in self.game_engine.scorecards],
+                "scorecards": {scorecard.player.name: scorecard.to_dict() for scorecard in self.game_engine.scorecards},
                 "current_turn": {
                     **self.game_engine.current_turn.to_dict(),
                     "valid_scores": [score.to_dict() for score in current_turn_valid_scores]


### PR DESCRIPTION
* Update the scorecard json output to a dictionary rather than a list (easier to parse on the front end)

Made to support this PR: https://github.com/jhu-binary-bits/yahtzee_ui/pull/13