### PR TITLE
you can now select 0 for any score that is not valid for your current…

### DIFF
--- a/src/app/state/state_manager.py
+++ b/src/app/state/state_manager.py
@@ -122,7 +122,7 @@ class StateManager:
                 "scorecards": {scorecard.player.name: scorecard.to_dict() for scorecard in self.game_engine.scorecards},
                 "current_turn": {
                     **self.game_engine.current_turn.to_dict(),
-                    "valid_scores": {score.score_type().value: score.calculate_potential_points(self.game_engine.current_turn.last_roll) for score in current_turn_valid_scores}
+                    "valid_scores": {score.score_type().value: score.calculate_potential_points(self.game_engine.current_turn.last_roll) for score in self.game_engine.current_scorecard.scores}
                 },
                 "game_winner": self.game_engine.game_winner
             }


### PR DESCRIPTION
… roll

Yahtzee rules state that you can select 0 for any score that your current roll does not apply to, so I added that. I believe this makes `get_valid_scores_for_roll()` obsolete, unless we decide to change it to return a dict of score types to point values to move a bit of logic from state_manager to entities.